### PR TITLE
Update README with DB initialization note

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,18 @@
    ```bash
    java -cp reservationsystem/dev_program_DB/lib/hsqldb.jar org.hsqldb.Server -database.0 file:reservationsystem/dev_program_DB/mydb/mydb -dbname.0 mydb
    ```
-2. Compile the sources:
+
+2. **First time only:** either run `setup.sql` using the HSQLDB tools or delete the existing `mydb.properties` and `mydb.script` files before starting the server so the schema is created again. The `setup.sql` script creates all tables including the `ROOM` table with its `TYPE` column required by `RoomSqlDao.createRoom`.
+
+3. Compile the sources:
    ```bash
    javac -cp reservationsystem/Waseda-SE/lib/hsqldb.jar -d reservationsystem/Waseda-SE/bin reservationsystem/Waseda-SE/src/**/*.java
    ```
-3. Initialize room data:
+4. Initialize room data:
    ```bash
    java -cp "reservationsystem/Waseda-SE/bin:reservationsystem/dev_program_DB/lib/hsqldb.jar" app.setup.RoomSetup
    ```
-4. Run the console UI:
+5. Run the console UI:
    ```bash
    java -cp "reservationsystem/Waseda-SE/bin:reservationsystem/dev_program_DB/lib/hsqldb.jar" app.cui.CUI
    ```


### PR DESCRIPTION
## Summary
- add instructions for running `setup.sql` or clearing old DB files on first run
- highlight that `setup.sql` creates the `ROOM` table with the `TYPE` column needed by `RoomSqlDao.createRoom`

## Testing
- `javac -cp reservationsystem/Waseda-SE/lib/hsqldb.jar -d reservationsystem/Waseda-SE/bin $(find reservationsystem/Waseda-SE/src -name '*.java')`

------
https://chatgpt.com/codex/tasks/task_e_6865cfcee880832c9fe26540ad8566fe